### PR TITLE
feat: add search for titles

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -15,7 +15,7 @@ module.exports = {
   pathPrefix: !IS_DEV ? '/taito-cli' : undefined,
 
   plugins: [
-    !IS_DEV && false && {
+    !IS_DEV && {
       resolve: 'gatsby-plugin-algolia',
       options: {
         appId: process.env.GATSBY_ALGOLIA_APP_ID,

--- a/www/package.json
+++ b/www/package.json
@@ -33,8 +33,7 @@
     "react-helmet": "^5.2.1",
     "react-icons": "^3.7.0",
     "react-instantsearch-dom": "^5.6.0",
-    "react-spring": "8.0.20",
-    "striptags": "^3.1.1"
+    "react-spring": "8.0.20"
   },
   "devDependencies": {
     "babel-plugin-transform-remove-console": "^6.9.4",


### PR DESCRIPTION
Remove the old logic that indexed all the text. Add logic to index only the page titles. Enable search.

#74 